### PR TITLE
Add Jest and ESLint GitHub Actions

### DIFF
--- a/.github/workflows/jest.yml
+++ b/.github/workflows/jest.yml
@@ -1,0 +1,17 @@
+name: Test Jest 🃏
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  test:
+    name: Jest Test 🃏
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+      - name: Install dependencies
+        run: yarn install
+      - name: Run tests
+        run: yarn turbo run test

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,17 @@
+name: Lint! 🍷
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  lint:
+    name: Run Eslint 🎯
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+      - name: Install dependencies
+        run: yarn install
+      - name: Run tests
+        run: yarn turbo run lint

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "format": "prettier --write \"**/*.{ts,tsx,md}\"",
     "changeset": "changeset",
     "version-packages": "changeset version",
-    "release": "turbo run build --filter=docs^... && changeset publish",
+    "release": "turbo run release --filter=docs^... && changeset publish",
     "test": "turbo run test"
   },
   "devDependencies": {

--- a/turbo.json
+++ b/turbo.json
@@ -18,6 +18,9 @@
     },
     "test": {
       "dependsOn": ["^test"]
+    },
+    "release": {
+      "dependsOn": ["build"]
     }
   }
 }


### PR DESCRIPTION
Add CI workflows and update release pipeline

Adds new GitHub Actions workflows for Jest testing and ESLint code quality checks. Both workflows trigger on pull requests to the main branch and run via Turborepo. Also updates the release pipeline to properly depend on build tasks.

The Jest workflow runs all tests across the monorepo using `turbo run test`, while the lint workflow enforces code style using `turbo run lint`. Both workflows use Ubuntu runners and install dependencies via Yarn.


> Important: I published the pkh on this branch to test changeset