### PR TITLE
Fix release script to use build command

### DIFF
--- a/.changeset/tiny-countries-cry.md
+++ b/.changeset/tiny-countries-cry.md
@@ -1,0 +1,5 @@
+---
+"@jackatdjl/djl-ui": minor
+---
+
+Hotfix: Did not Publish Correctly

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "format": "prettier --write \"**/*.{ts,tsx,md}\"",
     "changeset": "changeset",
     "version-packages": "changeset version",
-    "release": "turbo run release#@jackatdjl/djl-ui && changeset publish",
+    "release": "turbo run build#@jackatdjl/djl-ui && changeset publish",
     "test": "turbo run test"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "format": "prettier --write \"**/*.{ts,tsx,md}\"",
     "changeset": "changeset",
     "version-packages": "changeset version",
-    "release": "turbo run release --filter=docs,storydocs^... && changeset publish",
+    "release": "turbo run release#@jackatdjl/djl-ui && changeset publish",
     "test": "turbo run test"
   },
   "devDependencies": {


### PR DESCRIPTION
Hotfix: Build Script Update

Updated release script to use `build` instead of `release` for `@jackatdjl/djl-ui` package in the Turborepo pipeline, ensuring correct package publishing.