### PR TITLE
Update UI component export patterns

### DIFF
--- a/.changeset/ninety-books-change.md
+++ b/.changeset/ninety-books-change.md
@@ -1,0 +1,5 @@
+---
+"@jackatdjl/djl-ui": minor
+---
+
+Made Every Component a Default Export

--- a/packages/ui/src/card.tsx
+++ b/packages/ui/src/card.tsx
@@ -1,1 +1,2 @@
-export * as Card from ">/card";
+import * as Card from ">/card";
+export default Card;

--- a/packages/ui/src/collapse.tsx
+++ b/packages/ui/src/collapse.tsx
@@ -1,3 +1,4 @@
 "use client";
 
-export * as Collapse from ">/collapse";
+import * as Collapse from ">/collapse";
+export default Collapse;

--- a/packages/ui/src/command.tsx
+++ b/packages/ui/src/command.tsx
@@ -1,3 +1,4 @@
 "use client";
 
-export * as Command from ">/command";
+import * as Command from ">/command";
+export default Command;

--- a/packages/ui/src/custom-card.tsx
+++ b/packages/ui/src/custom-card.tsx
@@ -1,1 +1,2 @@
-export * as CustomCards from ">/custom-card";
+import * as CustomCards from ">/custom-card";
+export default CustomCards;

--- a/packages/ui/src/dialog.tsx
+++ b/packages/ui/src/dialog.tsx
@@ -1,3 +1,4 @@
 "use client";
 
-export * as Dialog from ">/dialog";
+import * as Dialog from ">/dialog";
+export default Dialog;

--- a/packages/ui/src/drawer.tsx
+++ b/packages/ui/src/drawer.tsx
@@ -1,3 +1,4 @@
 "use client";
 
-export * as Drawer from ">/drawer";
+import * as Drawer from ">/drawer";
+export default Drawer;

--- a/packages/ui/src/floating-panel.tsx
+++ b/packages/ui/src/floating-panel.tsx
@@ -1,1 +1,2 @@
-export * as FloatingPanel from ">/floating-panel";
+import * as FloatingPanel from ">/floating-panel";
+export default FloatingPanel;

--- a/packages/ui/src/fx/bg-boxes.tsx
+++ b/packages/ui/src/fx/bg-boxes.tsx
@@ -1,3 +1,4 @@
 "use client";
 
-export * as BgBoxes from "$/bg-boxes";
+import * as BgBoxes from "$/bg-boxes";
+export default BgBoxes;

--- a/packages/ui/src/fx/hover-cards.tsx
+++ b/packages/ui/src/fx/hover-cards.tsx
@@ -1,3 +1,4 @@
 "use client";
 
-export * as HoverCards from "$/hover-cards";
+import * as HoverCards from "$/hover-cards";
+export default HoverCards;

--- a/packages/ui/src/fx/spring-numbers.tsx
+++ b/packages/ui/src/fx/spring-numbers.tsx
@@ -1,3 +1,4 @@
 "use client";
 
-export * as SpringNumbers from "$/spring-numbers";
+import * as SpringNumbers from "$/spring-numbers";
+export default SpringNumbers;

--- a/packages/ui/src/fx/typewriter.tsx
+++ b/packages/ui/src/fx/typewriter.tsx
@@ -1,2 +1,3 @@
 "use client";
-export * as Typewriter from "$/typewriter";
+import * as Typewriter from "$/typewriter";
+export default Typewriter;

--- a/packages/ui/src/inputs.tsx
+++ b/packages/ui/src/inputs.tsx
@@ -1,1 +1,2 @@
-export * as Input from ">/inputs";
+import * as Input from ">/inputs";
+export default Input;

--- a/packages/ui/src/popup.tsx
+++ b/packages/ui/src/popup.tsx
@@ -1,2 +1,3 @@
 "use client";
-export * as Popup from ">/popup";
+import * as Popup from ">/popup";
+export default Popup;

--- a/packages/ui/src/radio-group.tsx
+++ b/packages/ui/src/radio-group.tsx
@@ -1,2 +1,3 @@
 "use client";
-export * as RadioGroup from ">/radio-group";
+import * as RadioGroup from ">/radio-group";
+export default RadioGroup;

--- a/packages/ui/src/scale-up.tsx
+++ b/packages/ui/src/scale-up.tsx
@@ -1,2 +1,3 @@
 "use client";
-export * as ScaleUp from ">/scale-up";
+import * as ScaleUp from ">/scale-up";
+export default ScaleUp;

--- a/packages/ui/src/scroll-area.tsx
+++ b/packages/ui/src/scroll-area.tsx
@@ -1,2 +1,3 @@
 "use client";
-export * as ScroolArea from ">/scroll-area";
+import * as ScrollArea from ">/scroll-area";
+export default ScrollArea;

--- a/packages/ui/src/sliders.tsx
+++ b/packages/ui/src/sliders.tsx
@@ -1,2 +1,3 @@
 "use client";
-export * as Sliders from ">/sliders";
+import * as Sliders from ">/sliders";
+export default Sliders;

--- a/packages/ui/src/sonner.tsx
+++ b/packages/ui/src/sonner.tsx
@@ -1,3 +1,4 @@
 "use client";
 
-export * as Sonner from ">/sonner";
+import * as Sonner from ">/sonner";
+export default Sonner;

--- a/packages/ui/src/tabs.tsx
+++ b/packages/ui/src/tabs.tsx
@@ -1,2 +1,3 @@
 "use client";
-export * as Tabs from ">/tabs";
+import * as Tabs from ">/tabs";
+export default Tabs;

--- a/packages/ui/src/toggle.tsx
+++ b/packages/ui/src/toggle.tsx
@@ -1,2 +1,3 @@
 "use client";
-export * as Toggle from ">/toggle";
+import * as Toggle from ">/toggle";
+export default Toggle;


### PR DESCRIPTION
### TL;DR
Changed UI component exports to use default exports instead of namespace exports

### What changed?
- Modified export statements across UI components to use default exports
- Fixed a typo in scroll-area.tsx (ScroolArea -> ScrollArea)
- Components now use explicit imports followed by default exports instead of direct namespace exports

### How to test?
1. Import any UI component using the new default export syntax
2. Verify components can be imported and used as expected
3. Pay special attention to ScrollArea component to ensure the fixed typo doesn't cause issues

### Why make this change?
This change improves the consistency of component imports and aligns with modern JavaScript/TypeScript best practices. Default exports provide a cleaner import syntax for consumers of these components and make the codebase more maintainable.