### PR TITLE
Fix UI package import patterns and overrides

### DIFF
--- a/.changeset/bright-chefs-occur.md
+++ b/.changeset/bright-chefs-occur.md
@@ -1,0 +1,5 @@
+---
+"@jackatdjl/djl-ui": patch
+---
+
+Patched a Problem making it Hard to import Components (fixed by creating overwrides and tossing javascript)

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -2,23 +2,26 @@
   "name": "@jackatdjl/djl-ui",
   "version": "0.4.0",
   "sideEffects": false,
+  "description": "This Package is typescript exclusive! (use the provided overwrites to use javascript)",
   "license": "MIT",
   "exports": {
     "./*": {
       "types": "./src/src/ui/*.tsx",
-      "import": "./dist/*.mjs",
+      "import": "./src/src/ui/*.tsx",
       "require": "./dist/*.js"
     },
     "./fx/*": {
       "types": "./src/src/fx/*.tsx",
-      "import": "./dist/fx/*.mjs",
+      "import": "./src/src/ui/*.tsx",
       "require": "./dist/fx/*.js"
     },
     "./tailwind": {
       "types": "./src/tailwind.ts",
-      "import": "./dist/tailwind.mjs",
+      "import": "./src/tailwind.ts",
       "require": "./dist/tailwind.js"
-    }
+    },
+    "./iknowtheout/*": "./dist/*",
+    "./iknowthesource/*": "./src/src/*"
   },
   "files": [
     "dist"


### PR DESCRIPTION
Changed Package to be Typescript Exclusive

Added overrides to allow javascript users to access the source and output directly through special paths.

Changeset:
- Patched a Problem making it Hard to import Components (fixed by creating overwrides and tossing javascript)