### PR TITLE
Fix UI package export patterns and defaults

### DIFF
--- a/.changeset/dirty-planes-sip.md
+++ b/.changeset/dirty-planes-sip.md
@@ -1,0 +1,13 @@
+---
+"@jackatdjl/djl-ui": patch
+---
+
+### Fixing a Problem incurring when importing components from my package
+
+#### Description
+
+This change fixes an issue where importing components from the `@jackatdjl/djl-ui` package would result in errors. The problem was caused by missing default exports in the package's `exports` field.
+
+#### Changes
+
+- Added default exports to the `exports` field in `package.json` to ensure that components can be imported correctly.

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -7,21 +7,25 @@
   "exports": {
     "./*": {
       "types": "./src/src/ui/*.tsx",
-      "import": "./src/src/ui/*.tsx",
-      "require": "./dist/*.js"
+      "import": "./dist/*.mjs",
+      "require": "./dist/*.js",
+      "node": "./src/src/ui/*.tsx",
+      "default": "./src/src/ui/*.tsx"
     },
     "./fx/*": {
       "types": "./src/src/fx/*.tsx",
-      "import": "./src/src/ui/*.tsx",
-      "require": "./dist/fx/*.js"
+      "import": "./dist/fx/*.mjs",
+      "require": "./dist/fx/*.js",
+      "node": "./src/src/fx/*.tsx",
+      "default": "./src/src/fx/*.tsx"
     },
     "./tailwind": {
       "types": "./src/tailwind.ts",
-      "import": "./src/tailwind.ts",
-      "require": "./dist/tailwind.js"
-    },
-    "./iknowtheout/*": "./dist/*",
-    "./iknowthesource/*": "./src/src/*"
+      "import": "./dist/tailwind.mjs",
+      "require": "./dist/tailwind.js",
+      "node": "./src/tailwind.ts",
+      "default": "./src/tailwind.ts"
+    }
   },
   "files": [
     "dist"


### PR DESCRIPTION
### TL;DR

Fixed component import errors in `@jackatdjl/djl-ui` by updating package exports configuration.

### What changed?

- Added `node` and `default` export configurations for UI components, FX components, and tailwind utilities
- Updated import paths to use `.mjs` extension for ESM imports
- Removed legacy `iknowtheout` and `iknowthesource` export paths

### How to test?

1. Import any component from the package using different module systems:
   ```js
   // ESM
   import { Component } from '@jackatdjl/djl-ui/component'
   
   // CommonJS
   const { Component } = require('@jackatdjl/djl-ui/component')
   ```
2. Verify that imports work without errors
3. Test imports for UI components, FX components, and tailwind utilities

### Why make this change?

Components were failing to import due to incomplete export configurations in `package.json`. This change ensures proper module resolution across different environments (Node.js, ESM, CommonJS) by providing appropriate export paths and file extensions.